### PR TITLE
Fix some links on the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,11 +37,11 @@ The main goal of project is to provide lightweight and performant tool without e
 
 <p>At this moment it offers high-performant streaming parsers for RDF/XML,
 <a href="http://en.wikipedia.org/wiki/Rdfa">RDFa</a>, N-Triples, streaming serializer for
-Turtle and integration with Jena and Clerezza.</p>
+Turtle and integration with Jena, Clerezza and Sesame.</p>
 
 <p>Small memory footprint, and CPU requirements allow framework to be embedded in any system.
-It runs seamlessly on Android and GAE. You can try
-<a href="http://demo.semarglproject.org" rel="homepage">RDFa parser demo</a> or visit
+It runs seamlessly on Android and GAE. You can try the
+<a href="http://demo.semarglproject.org" rel="homepage">RDFa parser demo</a> or visit the
 <a href="https://github.com/levkhomich/semargl">project page</a> at github.</p>
 
 <h1>Supported W3C specifications</h1>
@@ -71,7 +71,7 @@ It runs seamlessly on Android and GAE. You can try
 <ul rel="implements">
     <li>RDF/XML Syntax Specification (<a href="http://www.w3.org/TR/2004/REC-rdf-syntax-grammar-20040210/">REC</a>)</li>
     <li>SVG Tiny 1.2 Metadata (<a href="www.w3.org/TR/2008/REC-SVGTiny12-20081222/metadata.html">REC</a>)</li>
-    <li>Terse RDF Triple Language (<a href="http://www.w3.org/TeamSubmission/2011/SUBM-turtle-20110328/">SUBM</a>)</li>
+    <li>Terse RDF Triple Language (<a href="http://www.w3.org/TR/turtle/">WD</a>)</li>
     <li>N-Triples (<a href="http://www.w3.org/2001/sw/RDFCore/ntriples/">IWD</a>)</li>
 </ul>
 
@@ -82,7 +82,7 @@ It runs seamlessly on Android and GAE. You can try
                                             rel="dc:creator maintainer developer foaf:maker">
 		<span property="foaf:name" rel="foaf:homepage" resource="http://levkhomich.ru/">Lev Khomich</span></a>.<br />
           Tactile theme by <a href="http://twitter.com/jasonlong">Jason Long</a>.<br />
-          Project licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0.html" rel="license">APL v2.0</a>
+          Project licensed under <a href="http://www.apache.org/licenses/LICENSE-2.0.html" rel="license">Apache License, Version 2.0</a>
         </footer>
 
             <a rel="repository" href="https://github.com/levkhomich/semargl.git" typeof="GitRepository">


### PR DESCRIPTION
Some of the links to specifications were out of date.

In addition, APL does not generally refer to Apache License, so changing that to use the standard name "Apache License, Version 2.0"
